### PR TITLE
increase memory limits for nexus3

### DIFF
--- a/nexus3-persistent-template.yaml
+++ b/nexus3-persistent-template.yaml
@@ -164,4 +164,4 @@ parameters:
   displayName: Max Memory
   name: MAX_MEMORY
   required: true
-  value: 1Gi
+  value: 2Gi

--- a/nexus3-persistent-template.yaml
+++ b/nexus3-persistent-template.yaml
@@ -59,7 +59,7 @@ objects:
               - echo
               - ok
             failureThreshold: 3
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
@@ -73,7 +73,7 @@ objects:
               path: /
               port: 8081
               scheme: HTTP
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
@@ -164,4 +164,4 @@ parameters:
   displayName: Max Memory
   name: MAX_MEMORY
   required: true
-  value: 2Gi
+  value: 4Gi

--- a/nexus3-template.yaml
+++ b/nexus3-template.yaml
@@ -150,4 +150,4 @@ parameters:
   displayName: Max Memory
   name: MAX_MEMORY
   required: true
-  value: 1Gi
+  value: 2Gi


### PR DESCRIPTION
The nexus3 templates won't start on OCP 3.11 with the default memory settings (1GB)